### PR TITLE
Running remote setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ Example configuration for running with Podman:
 }
 ```
 
+## Connecting to a remote instance
+
+Example configuration for connecting to a remote instance:
+
+```json
+{
+  "mcpServers": {
+    "jira-mcp-snowflake": {
+      "url": "https://jira-mcp-snowflake.example.com/sse",
+      "headers": {
+        "X-Snowflake-Token": "your_token_here"
+      }
+    }
+  }
+}
+```
+
 ### VS Code Continue Integration
 
 Example configuration to add to VS Code Continue:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -18,9 +18,15 @@ logger = logging.getLogger(__name__)
 
 mcp = FastMCP("jira-mcp-snowflake")
 
+MCP_TRANSPORT = os.environ.get("MCP_TRANSPORT", "stdio")
+
 # Snowflake API configuration from environment variables
 SNOWFLAKE_BASE_URL = os.environ.get("SNOWFLAKE_BASE_URL", "https://gdadclc-rhprod.snowflakecomputing.com/api/v2")
-SNOWFLAKE_TOKEN = os.environ.get("SNOWFLAKE_TOKEN")
+SNOWFLAKE_TOKEN = (
+    os.environ["SNOWFLAKE_TOKEN"]
+    if MCP_TRANSPORT == "stdio"
+    else mcp.get_context().request_context.request.headers["X-Snowflake-Token"]
+)
 SNOWFLAKE_DATABASE = os.environ.get("SNOWFLAKE_DATABASE", "JIRA_DB")
 SNOWFLAKE_SCHEMA = os.environ.get("SNOWFLAKE_SCHEMA", "RHAI_MARTS")
 
@@ -438,4 +444,4 @@ async def get_project_summary() -> Dict[str, Any]:
         return {"error": f"Error generating project summary from Snowflake: {str(e)}"}
 
 if __name__ == "__main__":
-    mcp.run(transport=os.environ.get("MCP_TRANSPORT", "stdio"))
+    mcp.run(transport=MCP_TRANSPORT)

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: jira-mcp-snowflake
+parameters:
+  - name: IMAGE
+    value: quay.io/redhat-ai-tools/jira-mcp-snowflake
+  - name: IMAGE_TAG
+    value: latest
+  - name: MCP_TRANSPORT
+    value: sse
+  - name: FASTMCP_HOST
+    value: "0.0.0.0"
+  - name: CERT_MANAGER_ISSUER_NAME
+    value: letsencrypt-dns
+  - name: MCP_HOST
+    value: jira-mcp-snowflake.example.com
+  - name: SNOWFLAKE_BASE_URL
+    value: https://gdadclc-rhprod.snowflakecomputing.com/api/v2
+  - name: SNOWFLAKE_DATABASE
+    value: JIRA_DB
+  - name: SNOWFLAKE_SCHEMA
+    value: RHAI_MARTS
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: jira-mcp-snowflake
+    name: jira-mcp-snowflake
+  spec:
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app: jira-mcp-snowflake
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: jira-mcp-snowflake
+      spec:
+        containers:
+        - name: jira-mcp-snowflake
+          image: ${IMAGE}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          env:
+          - name: MCP_TRANSPORT
+            value: ${MCP_TRANSPORT}
+          - name: FASTMCP_HOST
+            value: ${FASTMCP_HOST}
+          - name: SNOWFLAKE_BASE_URL
+            value: ${SNOWFLAKE_BASE_URL}
+          - name: SNOWFLAKE_DATABASE
+            value: ${SNOWFLAKE_DATABASE}
+          - name: SNOWFLAKE_SCHEMA
+            value: ${SNOWFLAKE_SCHEMA}
+          ports:
+          - containerPort: 8000
+            protocol: TCP
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: jira-mcp-snowflake
+    labels:
+      app: jira-mcp-snowflake
+  spec:
+    selector:
+      app: jira-mcp-snowflake
+    ports:
+      - protocol: TCP
+        port: 8000
+        targetPort: 8000
+    type: ClusterIP
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      cert-manager.io/issuer-kind: ClusterIssuer
+      cert-manager.io/issuer-name: ${CERT_MANAGER_ISSUER_NAME}
+    name: jira-mcp-snowflake
+    labels:
+      app: jira-mcp-snowflake
+  spec:
+    host: ${MCP_HOST}
+    to:
+      kind: Service
+      name: jira-mcp-snowflake
+    port:
+      targetPort: 8000
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-httpx
-fastmcp
+httpx==0.28.1
+fastmcp==2.8.0


### PR DESCRIPTION
part of #4

in this PR we add an OpenShift template to deploy this MCP server in a centralized location, to be accessible via `url`.
users will need to provide their own token via the request headers, and the MCP server will hand them over to the snowflake instance.